### PR TITLE
build: setup build automation and checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,47 @@
+name: build
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        config:
+        - host: macos-latest
+          system: x86_64-darwin
+          target: aarch64-apple-darwin
+
+        - host: macos-latest
+          system: x86_64-darwin
+          target: x86_64-apple-darwin
+
+        - host: ubuntu-latest
+          system: x86_64-linux
+          target: aarch64-unknown-linux-musl
+
+        - host: ubuntu-latest
+          system: x86_64-linux
+          target: x86_64-unknown-linux-musl
+
+    runs-on: ${{ matrix.config.host }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v18
+      with:
+        extra_nix_config: |
+          access-tokens = github.com=${{ github.token }}
+    - uses: cachix/cachix-action@v11
+      with:
+        name: enarx
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - run: rustup show
+    - run: cargo update
+    - run: git add -f Cargo.lock
+    - run: nix build -L --show-trace '.#checks.${{ matrix.config.system }}.vfs-${{ matrix.config.target }}'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,66 @@
+name: check
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  nix-fmt:
+    name: "nix fmt"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v18
+      with:
+        extra_nix_config: |
+          access-tokens = github.com=${{ github.token }}
+    - uses: cachix/cachix-action@v11
+      with:
+        name: enarx
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - run: nix fmt
+
+  checks:
+    strategy:
+      matrix:
+        config:
+        - host: macos-latest
+          system: x86_64-darwin
+          check: clippy
+
+        - host: macos-latest
+          system: x86_64-darwin
+          check: nextest
+
+        - host: ubuntu-latest
+          system: x86_64-linux
+          check: clippy
+
+        - host: ubuntu-latest
+          system: x86_64-linux
+          check: nextest
+
+        - host: ubuntu-latest
+          system: x86_64-linux
+          check: fmt
+
+    runs-on: ${{ matrix.config.host }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v18
+      with:
+        extra_nix_config: |
+          access-tokens = github.com=${{ github.token }}
+    - uses: cachix/cachix-action@v11
+      with:
+        name: enarx
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - run: rustup show
+    - run: cargo update
+    - run: git add -f Cargo.lock
+    - run: nix build -L --show-trace '.#checks.${{ matrix.config.system }}.${{ matrix.config.check }}'

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,29 @@
+name: update
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  nix-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: nixbuild/nix-quick-install-action@v18
+        with:
+          nix_conf: |
+            experimental-features = nix-command flakes
+            access-tokens = github.com=${{ github.token }}
+      - uses: jessestricker/nix-flake-update@v1
+        id: nix-update
+      - uses: peter-evans/create-pull-request@v4
+        with:
+          branch: nix-update
+          commit-message: "build(nix): update flake lock"
+          title: "build(nix): update flake lock"
+          body: ${{ steps.nix-update.outputs.pull-request-body }}
+          labels: dependencies, nix
+          assignees: |
+            rvolosatovs
+          signoff: true

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,150 @@
+{
+  "nodes": {
+    "crane": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": [
+          "nixify",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixify",
+          "nixpkgs"
+        ],
+        "rust-overlay": [
+          "nixify",
+          "rust-overlay"
+        ]
+      },
+      "locked": {
+        "lastModified": 1666145618,
+        "narHash": "sha256-JG5UNASFzfzFmU0OktCASVDTCm5p71rtMnUcATBD2Y8=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "097afacc53a0a5fc23c212e5fe2a337ea53cdf0b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixify": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixlib": "nixlib",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1666279775,
+        "narHash": "sha256-xUJvmLzb/9ZX79EbHrRKLI+C56XInkzPjYK2xxfGrHI=",
+        "owner": "rvolosatovs",
+        "repo": "nixify",
+        "rev": "2d88ef3c5e62ce416d2ea5da41602bf439ff04f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rvolosatovs",
+        "repo": "nixify",
+        "type": "github"
+      }
+    },
+    "nixlib": {
+      "locked": {
+        "lastModified": 1665882590,
+        "narHash": "sha256-+kIvUKZe7RCjwg4NX2pMhO4CN9VplGtTl/XK5XDR2Zo=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "07aca231dce1aa0a744bedca29dd3e702eb0343c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1666215216,
+        "narHash": "sha256-SqcqjDPp/5C1rW2YhE9vqnz9BMuiveybcBL6WaRxIfg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "451c1a3e32ac73288d0f6fa48d53c9f2c1c5a3d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-22.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixify": "nixify"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "nixify",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixify",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1666148516,
+        "narHash": "sha256-pFgSJzUFsnCTulIzhn3HHImaZpqlMxAvXTrhg0qlMOE=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "3e41700ab6f585b9569112ee7516c74f8d072989",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  inputs.nixify.url = github:rvolosatovs/nixify;
+
+  outputs = {nixify, ...}:
+    nixify.lib.rust.mkFlake {
+      name = "vfs";
+      src = ./.;
+
+      ignorePaths = [
+        "/.github"
+        "/.gitignore"
+        "/flake.lock"
+        "/flake.nix"
+        "/rust-toolchain.toml"
+      ];
+
+      targets.wasm32-wasi = false; # wasi-common fails to compile for wasi
+
+      test.allFeatures = true;
+      test.allTargets = true;
+      test.noDefaultFeatures = false;
+      test.workspace = true;
+
+      clippy.allFeatures = true;
+      clippy.allTargets = true;
+      clippy.deny = ["warnings"];
+      clippy.noDefaultFeatures = false;
+      clippy.workspace = true;
+    };
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,9 @@
 [toolchain]
 channel = "nightly"
+targets = [
+    "aarch64-apple-darwin",
+    "aarch64-unknown-linux-musl",
+    "wasm32-wasi",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-linux-musl",
+]

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -101,6 +101,7 @@ test
 }
 
 #[test]
+#[ignore = "tmpfs is currently broken on WASI"] // TODO: Make tmpfs run on WASI
 async fn tmpfs() -> anyhow::Result<()> {
     let ledger = Ledger::new();
     let dir = wasmtime_vfs_tmpfs::Builder::from(Arc::clone(&ledger))

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -32,7 +32,7 @@ fn wash<I: Read + Sync + Send + 'static>(
             .stderr(Box::new(stderr.clone()))
             .build();
         ctx.push_preopened_dir(dir, "/")
-            .with_context(|| format!("failed to push directory"))?;
+            .context("failed to push directory")?;
 
         let mut store = Store::new(&engine, ctx);
         linker


### PR DESCRIPTION
`nix flake check`:
- Executes `cargo nextest`
- Executes `cargo fmt`
- Executes `cargo clippy`
- Builds the workspace for all supported targets on host system (incl x86_64 <-> aarch64 cross, unfortunately aarch64 Darwin -> x86_64 Darwin is currently broken due to Apple SDK versioning issues)

Selective checks/builds can be selected like so:
- `nix build .#checks.aarch64-darwin.nextest`
- `nix build .#checks.aarch64-linux.vfs-debug`
- `nix build .#checks.x86_64-darwin.vfs-aarch64-apple-darwin`
- `nix build .#checks.x86_64-linux.vfs`
- `nix build .#checks.x86_64-linux.vfs-aarch64-unknown-linux-musl`

This would very much benefit from setting `CACHIX_AUTH_TOKEN` to push to the https://app.cachix.org/cache/enarx binary cache

All checks run in `--release` profile by default, but that can be changed if desired

See `nix flake show github:rvolosatovs/vfs/ci/build`:
```
$ nix flake show github:rvolosatovs/vfs/ci/build
github:rvolosatovs/vfs/829e1f79198bb008b40ff8abf5ef0d3f1a4cfa07
├───checks
│   ├───aarch64-darwin
│   │   ├───clippy: derivation 'vfs-clippy-0.0.0-unspecified'
│   │   ├───fmt: derivation 'vfs-fmt-0.0.0-unspecified'
│   │   ├───nextest: derivation 'vfs-nextest-0.0.0-unspecified'
│   │   ├───vfs: derivation 'vfs-0.0.0-unspecified'
│   │   ├───vfs-aarch64-apple-darwin: derivation 'vfs-0.0.0-unspecified'
│   │   ├───vfs-debug: derivation 'vfs-0.0.0-unspecified'
│   │   └───vfs-debug-aarch64-apple-darwin: derivation 'vfs-0.0.0-unspecified'
│   ├───aarch64-linux
│   │   ├───clippy: derivation 'vfs-clippy-0.0.0-unspecified'
│   │   ├───fmt: derivation 'vfs-fmt-0.0.0-unspecified'
│   │   ├───nextest: derivation 'vfs-nextest-0.0.0-unspecified'
│   │   ├───vfs: derivation 'vfs-0.0.0-unspecified'
│   │   ├───vfs-aarch64-unknown-linux-musl: derivation 'vfs-0.0.0-unspecified'
│   │   ├───vfs-debug: derivation 'vfs-0.0.0-unspecified'
│   │   ├───vfs-debug-aarch64-unknown-linux-musl: derivation 'vfs-0.0.0-unspecified'
│   │   ├───vfs-debug-x86_64-unknown-linux-musl: derivation 'vfs-x86_64-unknown-linux-gnu-0.0.0-unspecified'
│   │   └───vfs-x86_64-unknown-linux-musl: derivation 'vfs-x86_64-unknown-linux-gnu-0.0.0-unspecified'
│   ├───powerpc64le-linux
│   │   ├───clippy: derivation 'vfs-clippy-0.0.0-unspecified'
│   │   ├───fmt: derivation 'vfs-fmt-0.0.0-unspecified'
│   │   ├───nextest: derivation 'vfs-nextest-0.0.0-unspecified'
│   │   ├───vfs: derivation 'vfs-0.0.0-unspecified'
│   │   ├───vfs-aarch64-unknown-linux-musl: derivation 'vfs-aarch64-unknown-linux-gnu-0.0.0-unspecified'
│   │   ├───vfs-debug: derivation 'vfs-0.0.0-unspecified'
│   │   ├───vfs-debug-aarch64-unknown-linux-musl: derivation 'vfs-aarch64-unknown-linux-gnu-0.0.0-unspecified'
│   │   ├───vfs-debug-x86_64-unknown-linux-musl: derivation 'vfs-x86_64-unknown-linux-gnu-0.0.0-unspecified'
│   │   └───vfs-x86_64-unknown-linux-musl: derivation 'vfs-x86_64-unknown-linux-gnu-0.0.0-unspecified'
│   ├───x86_64-darwin
│   │   ├───clippy: derivation 'vfs-clippy-0.0.0-unspecified'
│   │   ├───fmt: derivation 'vfs-fmt-0.0.0-unspecified'
│   │   ├───nextest: derivation 'vfs-nextest-0.0.0-unspecified'
│   │   ├───vfs: derivation 'vfs-0.0.0-unspecified'
│   │   ├───vfs-aarch64-apple-darwin: derivation 'vfs-aarch64-apple-darwin-0.0.0-unspecified'
│   │   ├───vfs-debug: derivation 'vfs-0.0.0-unspecified'
│   │   ├───vfs-debug-aarch64-apple-darwin: derivation 'vfs-aarch64-apple-darwin-0.0.0-unspecified'
│   │   ├───vfs-debug-x86_64-apple-darwin: derivation 'vfs-0.0.0-unspecified'
│   │   └───vfs-x86_64-apple-darwin: derivation 'vfs-0.0.0-unspecified'
│   └───x86_64-linux
│       ├───clippy: derivation 'vfs-clippy-0.0.0-unspecified'
│       ├───fmt: derivation 'vfs-fmt-0.0.0-unspecified'
│       ├───nextest: derivation 'vfs-nextest-0.0.0-unspecified'
│       ├───vfs: derivation 'vfs-0.0.0-unspecified'
│       ├───vfs-aarch64-unknown-linux-musl: derivation 'vfs-aarch64-unknown-linux-gnu-0.0.0-unspecified'
│       ├───vfs-debug: derivation 'vfs-0.0.0-unspecified'
│       ├───vfs-debug-aarch64-unknown-linux-musl: derivation 'vfs-aarch64-unknown-linux-gnu-0.0.0-unspecified'
│       ├───vfs-debug-x86_64-unknown-linux-musl: derivation 'vfs-0.0.0-unspecified'
│       └───vfs-x86_64-unknown-linux-musl: derivation 'vfs-0.0.0-unspecified'
├───devShells
│   ├───aarch64-darwin
│   │   └───default: development environment 'nix-shell'
│   ├───aarch64-linux
│   │   └───default: development environment 'nix-shell'
│   ├───powerpc64le-linux
│   │   └───default: development environment 'nix-shell'
│   ├───x86_64-darwin
│   │   └───default: development environment 'nix-shell'
│   └───x86_64-linux
│       └───default: development environment 'nix-shell'
├───formatter
│   ├───aarch64-darwin: package 'alejandra-1.4.0'
│   ├───aarch64-linux: package 'alejandra-1.4.0'
│   ├───powerpc64le-linux: package 'alejandra-1.4.0'
│   ├───x86_64-darwin: package 'alejandra-1.4.0'
│   └───x86_64-linux: package 'alejandra-1.4.0'
├───overlays
│   ├───default: Nixpkgs overlay
│   ├───rust: Nixpkgs overlay
│   └───vfs: Nixpkgs overlay
└───packages
    ├───aarch64-darwin
    ├───aarch64-linux
    ├───powerpc64le-linux
    ├───x86_64-darwin
    └───x86_64-linux
```