### PR TITLE
fix: address clippy warning

### DIFF
--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,6 +1,5 @@
 use std::fs::File;
 use std::io::Read;
-use std::sync::Arc;
 
 use anyhow::{bail, Context};
 use tempfile::tempdir;


### PR DESCRIPTION
```
$ cargo clippy --workspace --all-targets -- -D warnings
    Checking vfs v0.1.0 (/home/rvolosatovs/src/github.com/profianinc/vfs)
error: unused import: `std::sync::Arc`
 --> tests/mod.rs:3:5
  |
3 | use std::sync::Arc;
  |     ^^^^^^^^^^^^^^
  |
  = note: `-D unused-imports` implied by `-D warnings`
```
