### PR TITLE
ci: enable dependabot on root

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,7 @@
 version: 2
 updates:
 - package-ecosystem: "cargo"
-  directory: "/ledger"
-  schedule:
-    interval: "daily"
-- package-ecosystem: "cargo"
-  directory: "/tmpfs"
+  directory: "/"
   schedule:
     interval: "daily"
 - package-ecosystem: "github-actions"


### PR DESCRIPTION
It appears that dependabot is smart enough to iterate over all Cargo.toml files in workspace

Signed-off-by: Roman Volosatovs <roman@profian.com>